### PR TITLE
Handle erroneous wiki responses for HTML which include 'Edit' links.

### DIFF
--- a/tests/extract_html_format_test.py
+++ b/tests/extract_html_format_test.py
@@ -108,3 +108,19 @@ class TestHtmlFormatExtracts(unittest.TestCase):
                 "<p>Text for section 5.1\n\n\n</p>"
             )
         )
+
+    def test_with_erroneous_edit(self):
+        page = self.wiki.page('Test_Edit')
+        self.maxDiff = None
+        section = page.section_by_title('Section with Edit')
+        self.assertEqual(section.title, 'Section with Edit')
+        self.assertEqual(
+            page.text,
+            (
+                "<p><b>Summary</b> text\n\n</p>\n\n" +
+                "<h2>Section 1</h2>\n" +
+                "<p>Text for section 1</p>\n\n"
+                "<h3>Section with Edit</h3>\n" +
+                "<p>Text for section with edit\n\n\n</p>"
+            )
+        )

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -108,6 +108,36 @@ _MOCK_DATA = {
             }
         }
     },
+    'en:action=query&prop=extracts&titles=Test_Edit&': {
+        "batchcomplete": "",
+        "warnings": {
+            "extracts": {
+                "*": "\"exlimit\" was too large for a whole article extracts request, lowered to 1."
+            }
+        },
+        "query": {
+            "normalized": [
+                {
+                    "from": "Test_Edit",
+                    "to": "Test Edit"
+                }
+            ],
+            "pages": {
+                "4": {
+                    "pageid": 4,
+                    "ns": 0,
+                    "title": "Test Edit",
+                    "extract": (
+                        "<p><b>Summary</b> text\n\n</p>\n" +
+                        "<h2>Section 1</h2>\n" +
+                        "<p>Text for section 1</p>\n\n\n" +
+                        "<h3><span id=\"s1.Edit\">Section with Edit</span><span>Edit</span></h3>\n" +
+                        "<p>Text for section with edit\n\n\n</p>"
+                    )
+                }
+            }
+        }
+    },
     'en:action=query&inprop=protection|talkid|watched|watchers|visitingwatchers|notificationtimestamp|subjectid|url|readable|preload|displaytitle&prop=info&titles=Test_1&': {
         "batchcomplete": "",
         "query": {

--- a/wikipediaapi/wikipedia.py
+++ b/wikipediaapi/wikipedia.py
@@ -65,7 +65,7 @@ RE_SECTION = {
     ExtractFormat.HTML: re.compile(
         r'\n? *<h(\d)[^>]*?>(<span[^>]*><\/span>)? *' +
         '(<span[^>]*>)? *(<span[^>]*><\/span>)? *(.*?) *' +
-        '(<\/span>)?<\/h\d>\n?'
+        '(<\/span>)?(<span>Edit<\/span>)?<\/h\d>\n?'            # Example page with 'Edit' erroneous links: https://bit.ly/2ui4FWs
     ),
     # ExtractFormat.PLAIN.value: re.compile(r'\n\n *(===*) (.*?) (===*) *\n'),
 }

--- a/wikipediaapi/wikipedia.py
+++ b/wikipediaapi/wikipedia.py
@@ -65,7 +65,9 @@ RE_SECTION = {
     ExtractFormat.HTML: re.compile(
         r'\n? *<h(\d)[^>]*?>(<span[^>]*><\/span>)? *' +
         '(<span[^>]*>)? *(<span[^>]*><\/span>)? *(.*?) *' +
-        '(<\/span>)?(<span>Edit<\/span>)?<\/h\d>\n?'            # Example page with 'Edit' erroneous links: https://bit.ly/2ui4FWs
+        '(<\/span>)?(<span>Edit<\/span>)?<\/h\d>\n?'
+        #                  ^^^^
+        # Example page with 'Edit' erroneous links: https://bit.ly/2ui4FWs
     ),
     # ExtractFormat.PLAIN.value: re.compile(r'\n\n *(===*) (.*?) (===*) *\n'),
 }


### PR DESCRIPTION
Encountered this problem using the library on some wiki pages.  This seems to handle the issue, but happy to hear suggestions about how it might be improved.