### PR TITLE
Separation of Request Arguments on Wikipedia Initialization Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,114 @@ ENV/
 # Documentation
 _build/
 pypi-doc.html
+
+
+# Created by https://www.gitignore.io/api/pycharm+all,jetbrains+all
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+### PyCharm+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+
+# Sensitive or high-churn files:
+
+# Gradle:
+
+# CMake
+
+# Mongo Explorer plugin:
+
+## File-based project format:
+
+## Plugin-specific files:
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Ruby plugin and RubyMine
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+### PyCharm+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+
+
+# End of https://www.gitignore.io/api/pycharm+all,jetbrains+all

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -1,0 +1,25 @@
+import unittest
+
+import wikipediaapi
+
+
+class TestRequest(unittest.TestCase):
+    query = 'Arthur Schopenhauer'
+
+    def test_request_without_kwargs(self):
+        wiki = wikipediaapi.Wikipedia()
+
+        try:
+            page = wiki.page(self.query)
+            summary = page.summary
+        except Exception as e:
+            self.fail('TestRequest::test_request_without_kwargs failed due to the exception: {}'.format(str(e)))
+
+    def test_request_with_kwargs(self):
+        wiki = wikipediaapi.Wikipedia(timeout=30.0)
+
+        try:
+            page = wiki.page(self.query)
+            summary = page.summary
+        except Exception as e:
+            self.fail('TestRequest::test_request_with_kwargs failed due to the exception: {}'.format(str(e)))

--- a/wikipediaapi/wikipedia.py
+++ b/wikipediaapi/wikipedia.py
@@ -81,20 +81,21 @@ class Wikipedia(object):
             self,
             language='en',
             extract_format=ExtractFormat.WIKI,
-            user_agent=(
-            'Wikipedia-API (https://github.com/martin-majlis/Wikipedia-API)'
-            ),
-            timeout=10.0
+            headers=None,
+            **kwargs
     ) -> None:
         '''
         Language of the API being requested.
         Select language from `list of all Wikipedias:
             <http://meta.wikimedia.org/wiki/List_of_Wikipedias>`.
         '''
+        kwargs.setdefault('timeout', 10.0)
+
         self.language = language.strip().lower()
-        self.user_agent = user_agent
         self.extract_format = extract_format
-        self.timeout = timeout
+        self.__headers = dict() if headers is None else headers
+        self.__headers.setdefault('User-Agent', 'Wikipedia-API (https://github.com/martin-majlis/Wikipedia-API)')
+        self.__request_kwargs = kwargs
 
     def page(
             self,
@@ -350,10 +351,7 @@ class Wikipedia(object):
         params: Dict[str, Any]
     ):
         base_url = 'http://' + page.language + '.wikipedia.org/w/api.php'
-        headers = {
-            'User-Agent': self.user_agent,
-            'Accept-Encoding': 'gzip',
-        }
+        headers = self.__headers.copy()
         logging.info(
             "Request URL: %s",
             base_url + "?" + "&".join(
@@ -366,7 +364,7 @@ class Wikipedia(object):
             base_url,
             params=params,
             headers=headers,
-            timeout=self.timeout,
+            **self.__request_kwargs
         )
         return r.json()
 

--- a/wikipediaapi/wikipedia.py
+++ b/wikipediaapi/wikipedia.py
@@ -94,7 +94,10 @@ class Wikipedia(object):
         self.language = language.strip().lower()
         self.extract_format = extract_format
         self.__headers = dict() if headers is None else headers
-        self.__headers.setdefault('User-Agent', 'Wikipedia-API (https://github.com/martin-majlis/Wikipedia-API)')
+        self.__headers.setdefault(
+            'User-Agent',
+            'Wikipedia-API (https://github.com/martin-majlis/Wikipedia-API)'
+        )
         self.__request_kwargs = kwargs
 
     def page(


### PR DESCRIPTION
# Rationale

There are several reasons why the logic of HTTP request and the logic of Wikipedia API content on `Wikipedia` initialization method. The first one is the good old *separation of concerns*, however this is not the only reason.

The initialization method signature of `Wikipedia` must have the first priority on the arguments of Wikipedia API has. `language` and `extract_format` arguments are already enough, yet there are many options put between these arguments such as `timeout` and `user_agent`.

`timeout` and `user_agent` arguments are totally related to *request*, not the structure of Wikipedia API. These options also might be limited. In a case where the location of server or unit tester's development computer might be in a country and under a ISP that Wikipedia access might be restricted. In this case, a proxy is a must to use. That's why, instead of letting developers do hackish solutions on `Wikipedia-API`'s API, we might let them pass arguments to in any call of `requests`'s methods, [which can take a lot of arguments](https://github.com/requests/requests/blob/master/requests/api.py#L19-L45). This PR also might cover up possible enhancements and updates on Wikipedia's API in the future.

# What Has Changed

 - **The initialization method of Wikipedia and Related Calls**: The method signature has changed in a way of backwards compatibility. The default for headers are kept with `dict::setdefault`.
 - **.gitignore**: I added Jetbrains and Pycharm lines to `.gitignore` because the library might get a future PR developed with these products, which might add unwanted meta-info files to the repository.

---

The test result generated by Pycharm can be found [here](https://github.com/martin-majlis/Wikipedia-API/files/2116995/Wikipedia-API_test-results.html.zip).