### PR TITLE
Adds wikitext extractor (closes #4)

### DIFF
--- a/tests/extract_wiki_format_test.py
+++ b/tests/extract_wiki_format_test.py
@@ -97,6 +97,38 @@ class TestWikiFormatExtracts(unittest.TestCase):
             )
         )
 
+    def test_wikitext(self):
+        wikitext = self.wiki.wikitext('Test_1')
+        self.assertEqual(
+            wikitext,
+            (
+            "Summary text\n\n\n" +
+            "== Section 1 ==\n" +
+            "Text for section 1\n\n\n" +
+            "=== Section 1.1 ===\n" +
+            "Text for section 1.1\n\n\n" +
+            "=== Section 1.2 ===\n" +
+            "Text for section 1.2\n\n\n" +
+            "== Section 2 ==\n" +
+            "Text for section 2\n\n\n" +
+            "== Section 3 ==\n" +
+            "Text for section 3\n\n\n" +
+            "== Section 4 ==\n\n\n" +
+            "=== Section 4.1 ===\n" +
+            "Text for section 4.1\n\n\n" +
+            "=== Section 4.2 ===\n" +
+            "Text for section 4.2\n\n\n" +
+            "==== Section 4.2.1 ====\n" +
+            "Text for section 4.2.1\n\n\n" +
+            "==== Section 4.2.2 ====\n" +
+            "Text for section 4.2.2\n\n\n" +
+            "== Section 5 ==\n" +
+            "Text for section 5\n\n\n" +
+            "=== Section 5.1 ===\n" +
+            "Text for section 5.1\n"
+            )
+        )
+
     def test_text_and_summary_without_sections(self):
         page = self.wiki.page('No_Sections')
         self.maxDiff = None

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -586,4 +586,36 @@ _MOCK_DATA = {
             }
         }
     },
+    'en:action=parse&page=Test_1&prop=wikitext&': {
+        "parse": {
+            "wikitext": {
+                "*": (
+                    "Summary text\n\n\n" +
+                    "== Section 1 ==\n" +
+                    "Text for section 1\n\n\n" +
+                    "=== Section 1.1 ===\n" +
+                    "Text for section 1.1\n\n\n" +
+                    "=== Section 1.2 ===\n" +
+                    "Text for section 1.2\n\n\n" +
+                    "== Section 2 ==\n" +
+                    "Text for section 2\n\n\n" +
+                    "== Section 3 ==\n" +
+                    "Text for section 3\n\n\n" +
+                    "== Section 4 ==\n\n\n" +
+                    "=== Section 4.1 ===\n" +
+                    "Text for section 4.1\n\n\n" +
+                    "=== Section 4.2 ===\n" +
+                    "Text for section 4.2\n\n\n" +
+                    "==== Section 4.2.1 ====\n" +
+                    "Text for section 4.2.1\n\n\n" +
+                    "==== Section 4.2.2 ====\n" +
+                    "Text for section 4.2.2\n\n\n" +
+                    "== Section 5 ==\n" +
+                    "Text for section 5\n\n\n" +
+                    "=== Section 5.1 ===\n" +
+                    "Text for section 5.1\n"
+                )
+            }
+        }
+    }
 }

--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -543,6 +543,22 @@ class Wikipedia(object):
 
         return self._build_categorymembers(v, page)
 
+    def wikitext(self, title: str) -> str:
+        """
+        Returns wikitext of a page
+
+        :param title: page title as used in Wikipedia URL
+        :return: wikitext of the page
+        """
+        page = self.page(title)
+        params = {
+            'page': title,
+            'action': 'parse',
+            'prop': 'wikitext'
+        }
+        raw = self._query(page, params)
+        return raw['parse']['wikitext']['*']
+
     def _query(
             self,
             page: 'WikipediaPage',


### PR DESCRIPTION
Adds the possibility to read wikitext.

```python
import wikipediaapi
wiki = wikipediaapi.Wikipedia('en')
wikitext = wiki.wikitext('Python (software)')
```

It works for every languages :

```python
import wikipediaapi
wiki_cz = wikipediaapi.Wikipedia('cz')
wikitext_cz = wiki.wikitext('Guido van Rossum')  # "Guido_van_Rossum" also works
```