### PR TITLE
Update __init__.py to fix "Namespace 110 not found"

### DIFF
--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -88,6 +88,7 @@ class Namespace(IntEnum):
     REFERENCE_TALK = 105
     BOOK = 108
     BOOK_TALK = 109
+    FIX = 110
     DRAFT = 118
     DRAFT_TALK = 119
     EDUCATION_PROGRAM = 446


### PR DESCRIPTION
If you try to get links on Romanian Wikipedia with page.links you get an error "ValueError: 110 is not a valid Namespace". If you add namespace 110 in the namespace class, the error disappears.