### PR TITLE
Add call to "pageterms" to gather alias, label and description of a page

### DIFF
--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -30,30 +30,30 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "Test 1",
                     "extract": (
-                            "Summary text\n\n\n" +
-                            "== Section 1 ==\n" +
-                            "Text for section 1\n\n\n" +
-                            "=== Section 1.1 ===\n" +
-                            "Text for section 1.1\n\n\n" +
-                            "=== Section 1.2 ===\n" +
-                            "Text for section 1.2\n\n\n" +
-                            "== Section 2 ==\n" +
-                            "Text for section 2\n\n\n" +
-                            "== Section 3 ==\n" +
-                            "Text for section 3\n\n\n" +
-                            "== Section 4 ==\n\n\n" +
-                            "=== Section 4.1 ===\n" +
-                            "Text for section 4.1\n\n\n" +
-                            "=== Section 4.2 ===\n" +
-                            "Text for section 4.2\n\n\n" +
-                            "==== Section 4.2.1 ====\n" +
-                            "Text for section 4.2.1\n\n\n" +
-                            "==== Section 4.2.2 ====\n" +
-                            "Text for section 4.2.2\n\n\n" +
-                            "== Section 5 ==\n" +
-                            "Text for section 5\n\n\n" +
-                            "=== Section 5.1 ===\n" +
-                            "Text for section 5.1\n"
+                        "Summary text\n\n\n" +
+                        "== Section 1 ==\n" +
+                        "Text for section 1\n\n\n" +
+                        "=== Section 1.1 ===\n" +
+                        "Text for section 1.1\n\n\n" +
+                        "=== Section 1.2 ===\n" +
+                        "Text for section 1.2\n\n\n" +
+                        "== Section 2 ==\n" +
+                        "Text for section 2\n\n\n" +
+                        "== Section 3 ==\n" +
+                        "Text for section 3\n\n\n" +
+                        "== Section 4 ==\n\n\n" +
+                        "=== Section 4.1 ===\n" +
+                        "Text for section 4.1\n\n\n" +
+                        "=== Section 4.2 ===\n" +
+                        "Text for section 4.2\n\n\n" +
+                        "==== Section 4.2.1 ====\n" +
+                        "Text for section 4.2.1\n\n\n" +
+                        "==== Section 4.2.2 ====\n" +
+                        "Text for section 4.2.2\n\n\n" +
+                        "== Section 5 ==\n" +
+                        "Text for section 5\n\n\n" +
+                        "=== Section 5.1 ===\n" +
+                        "Text for section 5.1\n"
                     )
                 }
             }
@@ -79,7 +79,7 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "No Sections",
                     "extract": (
-                        "Summary text\n\n\n"
+                            "Summary text\n\n\n"
                     )
                 }
             }
@@ -105,30 +105,30 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "Test 1",
                     "extract": (
-                            "<p><b>Summary</b> text\n\n</p>\n" +
-                            "<h2>Section 1</h2>\n" +
-                            "<p>Text for section 1</p>\n\n\n" +
-                            "<h3><span id=\"s1.1\">Section 1.1</span></h3>\n" +
-                            "<p><b>Text for section 1.1</b>\n\n\n</p>" +
-                            "<h3>Section 1.2</h3>\n" +
-                            "<p><b>Text for section 1.2</b>\n\n\n</p>" +
-                            "<h2><span id=\"s2\">Section 2</span></h2>\n" +
-                            "<p><b>Text for section 2</b>\n\n\n</p>" +
-                            "<h2><span id=\'s3\'>Section 3</span></h2>\n" +
-                            "<p><b>Text for section 3</b>\n\n\n</p>" +
-                            "<h2 id=\"s4\">Section 4</h2>\n" +
-                            "<h3><span id=\"s4.1\">Section 4.1</span></h3>\n" +
-                            "<p><b>Text for section 4.1</b>\n\n\n</p>" +
-                            "<h3><span id=\"s4.2\">Section 4.2</span></h3>\n" +
-                            "<p><b>Text for section 4.2</b>\n\n\n</p>" +
-                            "<h4><span id=\"s4.2.1\">Section 4.2.1</span></h4>\n" +
-                            "<p><b>Text for section 4.2.1</b>\n\n\n</p>" +
-                            "<h4><span id=\"s4.2.2\">Section 4.2.2</span></h4>\n" +
-                            "<p><b>Text for section 4.2.2</b>\n\n\n</p>" +
-                            "<h2><span id=\"s5a\"></span><span id=\"s5b\">Section 5</span></h2>\n" +
-                            "<p><b>Text for section 5</b>\n\n\n</p>" +
-                            "<h3><span id=\"s5.1\">Section 5.1</span></h3>\n" +
-                            "<p>Text for section 5.1\n\n\n</p>"
+                        "<p><b>Summary</b> text\n\n</p>\n" +
+                        "<h2>Section 1</h2>\n" +
+                        "<p>Text for section 1</p>\n\n\n" +
+                        "<h3><span id=\"s1.1\">Section 1.1</span></h3>\n" +
+                        "<p><b>Text for section 1.1</b>\n\n\n</p>" +
+                        "<h3>Section 1.2</h3>\n" +
+                        "<p><b>Text for section 1.2</b>\n\n\n</p>" +
+                        "<h2><span id=\"s2\">Section 2</span></h2>\n" +
+                        "<p><b>Text for section 2</b>\n\n\n</p>" +
+                        "<h2><span id=\'s3\'>Section 3</span></h2>\n" +
+                        "<p><b>Text for section 3</b>\n\n\n</p>" +
+                        "<h2 id=\"s4\">Section 4</h2>\n" +
+                        "<h3><span id=\"s4.1\">Section 4.1</span></h3>\n" +
+                        "<p><b>Text for section 4.1</b>\n\n\n</p>" +
+                        "<h3><span id=\"s4.2\">Section 4.2</span></h3>\n" +
+                        "<p><b>Text for section 4.2</b>\n\n\n</p>" +
+                        "<h4><span id=\"s4.2.1\">Section 4.2.1</span></h4>\n" +
+                        "<p><b>Text for section 4.2.1</b>\n\n\n</p>" +
+                        "<h4><span id=\"s4.2.2\">Section 4.2.2</span></h4>\n" +
+                        "<p><b>Text for section 4.2.2</b>\n\n\n</p>" +
+                        "<h2><span id=\"s5a\"></span><span id=\"s5b\">Section 5</span></h2>\n" +
+                        "<p><b>Text for section 5</b>\n\n\n</p>" +
+                        "<h3><span id=\"s5.1\">Section 5.1</span></h3>\n" +
+                        "<p>Text for section 5.1\n\n\n</p>"
                     )
                 }
             }
@@ -154,11 +154,11 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "Test Edit",
                     "extract": (
-                            "<p><b>Summary</b> text\n\n</p>\n" +
-                            "<h2>Section 1</h2>\n" +
-                            "<p>Text for section 1</p>\n\n\n" +
-                            "<h3><span id=\"s1.Edit\">Section with Edit</span><span>Edit</span></h3>\n" +
-                            "<p>Text for section with edit\n\n\n</p>"
+                        "<p><b>Summary</b> text\n\n</p>\n" +
+                        "<h2>Section 1</h2>\n" +
+                        "<p>Text for section 1</p>\n\n\n" +
+                        "<h3><span id=\"s1.Edit\">Section with Edit</span><span>Edit</span></h3>\n" +
+                        "<p>Text for section with edit\n\n\n</p>"
                     )
                 }
             }

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -30,30 +30,30 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "Test 1",
                     "extract": (
-                        "Summary text\n\n\n" +
-                        "== Section 1 ==\n" +
-                        "Text for section 1\n\n\n" +
-                        "=== Section 1.1 ===\n" +
-                        "Text for section 1.1\n\n\n" +
-                        "=== Section 1.2 ===\n" +
-                        "Text for section 1.2\n\n\n" +
-                        "== Section 2 ==\n" +
-                        "Text for section 2\n\n\n" +
-                        "== Section 3 ==\n" +
-                        "Text for section 3\n\n\n" +
-                        "== Section 4 ==\n\n\n" +
-                        "=== Section 4.1 ===\n" +
-                        "Text for section 4.1\n\n\n" +
-                        "=== Section 4.2 ===\n" +
-                        "Text for section 4.2\n\n\n" +
-                        "==== Section 4.2.1 ====\n" +
-                        "Text for section 4.2.1\n\n\n" +
-                        "==== Section 4.2.2 ====\n" +
-                        "Text for section 4.2.2\n\n\n" +
-                        "== Section 5 ==\n" +
-                        "Text for section 5\n\n\n" +
-                        "=== Section 5.1 ===\n" +
-                        "Text for section 5.1\n"
+                            "Summary text\n\n\n" +
+                            "== Section 1 ==\n" +
+                            "Text for section 1\n\n\n" +
+                            "=== Section 1.1 ===\n" +
+                            "Text for section 1.1\n\n\n" +
+                            "=== Section 1.2 ===\n" +
+                            "Text for section 1.2\n\n\n" +
+                            "== Section 2 ==\n" +
+                            "Text for section 2\n\n\n" +
+                            "== Section 3 ==\n" +
+                            "Text for section 3\n\n\n" +
+                            "== Section 4 ==\n\n\n" +
+                            "=== Section 4.1 ===\n" +
+                            "Text for section 4.1\n\n\n" +
+                            "=== Section 4.2 ===\n" +
+                            "Text for section 4.2\n\n\n" +
+                            "==== Section 4.2.1 ====\n" +
+                            "Text for section 4.2.1\n\n\n" +
+                            "==== Section 4.2.2 ====\n" +
+                            "Text for section 4.2.2\n\n\n" +
+                            "== Section 5 ==\n" +
+                            "Text for section 5\n\n\n" +
+                            "=== Section 5.1 ===\n" +
+                            "Text for section 5.1\n"
                     )
                 }
             }
@@ -79,7 +79,7 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "No Sections",
                     "extract": (
-                            "Summary text\n\n\n"
+                        "Summary text\n\n\n"
                     )
                 }
             }
@@ -105,30 +105,30 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "Test 1",
                     "extract": (
-                        "<p><b>Summary</b> text\n\n</p>\n" +
-                        "<h2>Section 1</h2>\n" +
-                        "<p>Text for section 1</p>\n\n\n" +
-                        "<h3><span id=\"s1.1\">Section 1.1</span></h3>\n" +
-                        "<p><b>Text for section 1.1</b>\n\n\n</p>" +
-                        "<h3>Section 1.2</h3>\n" +
-                        "<p><b>Text for section 1.2</b>\n\n\n</p>" +
-                        "<h2><span id=\"s2\">Section 2</span></h2>\n" +
-                        "<p><b>Text for section 2</b>\n\n\n</p>" +
-                        "<h2><span id=\'s3\'>Section 3</span></h2>\n" +
-                        "<p><b>Text for section 3</b>\n\n\n</p>" +
-                        "<h2 id=\"s4\">Section 4</h2>\n" +
-                        "<h3><span id=\"s4.1\">Section 4.1</span></h3>\n" +
-                        "<p><b>Text for section 4.1</b>\n\n\n</p>" +
-                        "<h3><span id=\"s4.2\">Section 4.2</span></h3>\n" +
-                        "<p><b>Text for section 4.2</b>\n\n\n</p>" +
-                        "<h4><span id=\"s4.2.1\">Section 4.2.1</span></h4>\n" +
-                        "<p><b>Text for section 4.2.1</b>\n\n\n</p>" +
-                        "<h4><span id=\"s4.2.2\">Section 4.2.2</span></h4>\n" +
-                        "<p><b>Text for section 4.2.2</b>\n\n\n</p>" +
-                        "<h2><span id=\"s5a\"></span><span id=\"s5b\">Section 5</span></h2>\n" +
-                        "<p><b>Text for section 5</b>\n\n\n</p>" +
-                        "<h3><span id=\"s5.1\">Section 5.1</span></h3>\n" +
-                        "<p>Text for section 5.1\n\n\n</p>"
+                            "<p><b>Summary</b> text\n\n</p>\n" +
+                            "<h2>Section 1</h2>\n" +
+                            "<p>Text for section 1</p>\n\n\n" +
+                            "<h3><span id=\"s1.1\">Section 1.1</span></h3>\n" +
+                            "<p><b>Text for section 1.1</b>\n\n\n</p>" +
+                            "<h3>Section 1.2</h3>\n" +
+                            "<p><b>Text for section 1.2</b>\n\n\n</p>" +
+                            "<h2><span id=\"s2\">Section 2</span></h2>\n" +
+                            "<p><b>Text for section 2</b>\n\n\n</p>" +
+                            "<h2><span id=\'s3\'>Section 3</span></h2>\n" +
+                            "<p><b>Text for section 3</b>\n\n\n</p>" +
+                            "<h2 id=\"s4\">Section 4</h2>\n" +
+                            "<h3><span id=\"s4.1\">Section 4.1</span></h3>\n" +
+                            "<p><b>Text for section 4.1</b>\n\n\n</p>" +
+                            "<h3><span id=\"s4.2\">Section 4.2</span></h3>\n" +
+                            "<p><b>Text for section 4.2</b>\n\n\n</p>" +
+                            "<h4><span id=\"s4.2.1\">Section 4.2.1</span></h4>\n" +
+                            "<p><b>Text for section 4.2.1</b>\n\n\n</p>" +
+                            "<h4><span id=\"s4.2.2\">Section 4.2.2</span></h4>\n" +
+                            "<p><b>Text for section 4.2.2</b>\n\n\n</p>" +
+                            "<h2><span id=\"s5a\"></span><span id=\"s5b\">Section 5</span></h2>\n" +
+                            "<p><b>Text for section 5</b>\n\n\n</p>" +
+                            "<h3><span id=\"s5.1\">Section 5.1</span></h3>\n" +
+                            "<p>Text for section 5.1\n\n\n</p>"
                     )
                 }
             }
@@ -154,11 +154,11 @@ _MOCK_DATA = {
                     "ns": 0,
                     "title": "Test Edit",
                     "extract": (
-                        "<p><b>Summary</b> text\n\n</p>\n" +
-                        "<h2>Section 1</h2>\n" +
-                        "<p>Text for section 1</p>\n\n\n" +
-                        "<h3><span id=\"s1.Edit\">Section with Edit</span><span>Edit</span></h3>\n" +
-                        "<p>Text for section with edit\n\n\n</p>"
+                            "<p><b>Summary</b> text\n\n</p>\n" +
+                            "<h2>Section 1</h2>\n" +
+                            "<p>Text for section 1</p>\n\n\n" +
+                            "<h3><span id=\"s1.Edit\">Section with Edit</span><span>Edit</span></h3>\n" +
+                            "<p>Text for section with edit\n\n\n</p>"
                     )
                 }
             }
@@ -582,6 +582,43 @@ _MOCK_DATA = {
                     "readable": "",
                     "preload": None,
                     "displaytitle": "पाइथन"
+                }
+            }
+        }
+    },
+    'en:action=query&prop=pageterms&titles=Test1&': {
+        "batchcomplete": "",
+        "query": {
+            "pages": {
+                "1": {
+                    "pageid": 1,
+                    "ns": 0,
+                    "title": "Test1",
+                    "terms": {
+                        "alias": [
+                            "Test 1",
+                            "Test one",
+                            "Test ONE"
+                        ],
+                        "label": [
+                            "Test 1"
+                        ],
+                        "description": [
+                            "test"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    'en:action=query&prop=pageterms&titles=Non_Existent&': {
+        "batchcomplete": "",
+        "query": {
+            "pages": {
+                "-1": {
+                    "ns": 0,
+                    "title": "Non Existent",
+                    "missing": ""
                 }
             }
         }

--- a/tests/page_terms_test.py
+++ b/tests/page_terms_test.py
@@ -1,0 +1,34 @@
+import unittest
+
+import wikipediaapi
+from tests.mock_data import wikipedia_api_request
+
+
+class TestPageTerm(unittest.TestCase):
+    def setUp(self):
+        self.wiki = wikipediaapi.Wikipedia("en")
+        self.wiki._query = wikipedia_api_request
+
+    def test_alias_good_parsing(self):
+        page = self.wiki.page('Test1')
+        self.assertEqual(page.alias, ["Test 1", "Test one", "Test ONE"])
+
+    def test_description_good_parsing(self):
+        page = self.wiki.page('Test1')
+        self.assertEqual(page.desc, ['test'])
+
+    def test_label_good_parsing(self):
+        page = self.wiki.page('Test1')
+        self.assertEqual(page.label, ['Test 1'])
+
+    def test_label_nonexistent_page(self):
+        page = self.wiki.page('Non_Existent')
+        self.assertEqual(page.label, [])
+
+    def test_alias_nonexistent_page(self):
+        page = self.wiki.page('Non_Existent')
+        self.assertEqual(page.alias, [])
+
+    def test_description_nonexistent_page(self):
+        page = self.wiki.page('Non_Existent')
+        self.assertEqual(page.desc, [])

--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -809,7 +809,6 @@ class Wikipedia(object):
     ) -> PagesDict:
 
         self._common_attributes(extract, page)
-
         page._pageterms = extract.get('terms', [])
         return page._pageterms
 
@@ -977,7 +976,7 @@ class WikipediaPage(object):
         self._backlinks = {}  # type: PagesDict
         self._categories = {}  # type: PagesDict
         self._categorymembers = {}  # type: PagesDict
-        self._pageterms = {'alias': [], 'label': [], 'description': []}  # type : PagesDict
+        self._pageterms = {}  # type : PagesDict
 
         self._called = {
             'extracts': False,
@@ -1203,7 +1202,7 @@ class WikipediaPage(object):
         """
         if not self._called['pageterms']:
             self._fetch('pageterms')
-        return self._pageterms['alias']
+        return self._pageterms.get('alias', [])
 
     @property
     def label(self) -> List[str]:
@@ -1214,7 +1213,7 @@ class WikipediaPage(object):
         """
         if not self._called['pageterms']:
             self._fetch('pageterms')
-        return self._pageterms['label']
+        return self._pageterms.get('label', [])
 
     @property
     def desc(self) -> List[str]:
@@ -1225,7 +1224,7 @@ class WikipediaPage(object):
         """
         if not self._called['pageterms']:
             self._fetch('pageterms')
-        return self._pageterms['description']
+        return self._pageterms.get('description', [])
 
     def _fetch(self, call) -> 'WikipediaPage':
         getattr(self.wiki, call)(self)


### PR DESCRIPTION
Pageterms is a parameter that gives us back information about a page like all the alias it has, it is available in every language.

Here is an example from an actual page from a Wikipedia page : 

[https://en.wikipedia.org/w/api.php?action=query&prop=pageterms&titles=Aarhus%20Airport](https://en.wikipedia.org/w/api.php?action=query&prop=pageterms&titles=Aarhus%20Airport)

