### PR TITLE
Add search_pages method to the Wikipedia class

### DIFF
--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -178,9 +178,9 @@ class Wikipedia:
 
         dummy_page = WikipediaPage(self, 0)  # Create a dummy page object for the _query method
         data = self._query(dummy_page, params)
-        pageids = [result["pageid"] for result in data["query"]["search"]]
+        titles = [result["title"] for result in data["query"]["search"]]
 
-        return [WikipediaPage(self, pageid) for pageid in pageids]
+        return [WikipediaPage(self, title) for title in titles]
 
     def page(
         self,

--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -161,6 +161,27 @@ class Wikipedia:
         """Closes session."""
         self._session.close()
 
+    def search_pages(self, query: str, limit: int = 10) -> list:
+        """
+        Searches for pages using a text query.
+
+        :param query: The search query.
+        :param limit: The maximum number of results to return. Default is 10.
+        :return: A list of page titles.
+        """
+        params = {
+            "action": "query",
+            "list": "search",
+            "srsearch": query,
+            "srlimit": limit,
+        }
+
+        dummy_page = WikipediaPage(self, 0)  # Create a dummy page object for the _query method
+        data = self._query(dummy_page, params)
+        pageids = [result["pageid"] for result in data["query"]["search"]]
+
+        return [WikipediaPage(self, pageid) for pageid in pageids]
+
     def page(
         self,
         title: str,


### PR DESCRIPTION
This pull request adds the search_pages method to the Wikipedia class, allowing users to search for pages using a text query. The method accepts a query string and an optional limit for the number of results to return (default is 10). The search results are returned as a list of WikipediaPage objects with their titles populated.

Here's a summary of the changes made:
- Added a new search_pages method to the Wikipedia class for searching pages using a text query.
- The method accepts a query string and an optional limit for the number of results to return.
- The search results are returned as a list of WikipediaPage objects with their titles populated.

Example:
```python
import wikipediaapi
wiki = wikipediaapi.Wikipedia()

print(wiki.search_pages("Set theory"))
# Output: [Set theory (id: ??, ns: 0),
# Complement (set theory) (id: ??, ns: 0),
# Class (set theory) (id: ??, ns: 0),
# Naive set theory (id: ??, ns: 0),
# Intersection (set theory) (id: ??, ns: 0),
# Zermelo–Fraenkel set theory (id: ??, ns: 0),
# Constructive set theory (id: ??, ns: 0),
# Union (set theory) (id: ??, ns: 0),
# Descriptive set theory (id: ??, ns: 0),
# Set theory (music) (id: ??, ns: 0)]

print(wiki.search_pages("nAvTvU*6j4p^JUjM!4$p"))
# Output: []
```
