### PR TITLE
2024-01-04: Small adjustments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/conf.py
+++ b/conf.py
@@ -50,7 +50,7 @@ master_doc = "README"
 
 # General information about the project.
 project = "Wikipedia Python API"
-copyright = '2017-2023, <a href="http://martin.majlis.cz">Martin Majlis</a>'
+copyright = '2017-2025, <a href="http://martin.majlis.cz">Martin Majlis</a>'
 author = "Martin Majlis"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,7 @@
 .. toctree::
 	:maxdepth: 2
 
-    README
+	README
 	API
 	CHANGES
 	DEVELOPMENT

--- a/index.rst
+++ b/index.rst
@@ -1,8 +1,1 @@
-.. toctree::
-	:maxdepth: 2
-
-	README
-	API
-	CHANGES
-	DEVELOPMENT
-	wikipediaapi/api
+README.rst


### PR DESCRIPTION
This PR adjusts:

* copyrights - extends to 2025
* adds testing for Python 3.13 into release GHA
* `index.rst` is now symlink to `README.rst`