### PR TITLE
feat: Handle situations when server is not returning JSON response

### DIFF
--- a/API.rst
+++ b/API.rst
@@ -3,7 +3,7 @@ API
 
 Wikipedia
 ---------
-* ``__init__(user_agent: str, language='en', variant=Optional[str] = None, extract_format=ExtractFormat.WIKI, headers: Optional[Dict[str, Any]] = None, extra_api_params: Optional[dict[str, Any]] = None, **request_kwargs)``
+* ``__init__(user_agent: str, language='en', variant=Optional[str] = None, extract_format=ExtractFormat.WIKI, headers: Optional[Dict[str, Any]] = None, extra_api_params: Optional[dict[str, Any]] = None, max_retries: int = 3, retry_wait: float = 1.0, **request_kwargs)``
 * ``page(title)``
 
 WikipediaPage
@@ -53,3 +53,39 @@ ExtractFormat
 -------------
 * ``WIKI``
 * ``HTML``
+
+Exceptions
+----------
+
+All exceptions raised by the library inherit from ``WikipediaException``.
+No ``requests`` or ``json`` exceptions are exposed.
+
+* ``WikipediaException`` - base exception for all Wikipedia-API errors
+* ``HttpError(status_code, url)`` - non-success HTTP status from Wikipedia API
+* ``RateLimitError(url, retry_after=None)`` - HTTP 429 Too Many Requests; subclass of ``HttpError``
+* ``HttpTimeoutError(url)`` - request to Wikipedia API timed out
+* ``InvalidJsonError(url)`` - response body was not valid JSON
+* ``ConnectionError(url)`` - could not connect to Wikipedia API
+
+Exception hierarchy::
+
+    WikipediaException
+    ├── HttpError
+    │   └── RateLimitError
+    ├── HttpTimeoutError
+    ├── InvalidJsonError
+    └── ConnectionError
+
+Retry Behavior
+--------------
+
+Transient errors (HTTP 429, 5xx, timeouts, connection errors) are retried
+automatically with exponential backoff. The behavior is controlled by two
+constructor parameters:
+
+* ``max_retries`` (default: ``3``) - maximum number of retry attempts; set to ``0`` to disable
+* ``retry_wait`` (default: ``1.0``) - base wait time in seconds; actual wait is ``retry_wait * 2^attempt``
+
+For HTTP 429, the ``Retry-After`` header is honored when present.
+
+Non-retryable errors (HTTP 4xx other than 429, invalid JSON) raise immediately.

--- a/API.rst
+++ b/API.rst
@@ -61,20 +61,20 @@ All exceptions raised by the library inherit from ``WikipediaException``.
 No ``requests`` or ``json`` exceptions are exposed.
 
 * ``WikipediaException`` - base exception for all Wikipedia-API errors
-* ``HttpError(status_code, url)`` - non-success HTTP status from Wikipedia API
-* ``RateLimitError(url, retry_after=None)`` - HTTP 429 Too Many Requests; subclass of ``HttpError``
-* ``HttpTimeoutError(url)`` - request to Wikipedia API timed out
-* ``InvalidJsonError(url)`` - response body was not valid JSON
-* ``ConnectionError(url)`` - could not connect to Wikipedia API
+* ``WikiHttpError(status_code, url)`` - non-success HTTP status from Wikipedia API
+* ``WikiRateLimitError(url, retry_after=None)`` - HTTP 429 Too Many Requests; subclass of ``WikiHttpError``
+* ``WikiHttpTimeoutError(url)`` - request to Wikipedia API timed out
+* ``WikiInvalidJsonError(url)`` - response body was not valid JSON
+* ``WikiConnectionError(url)`` - could not connect to Wikipedia API
 
 Exception hierarchy::
 
     WikipediaException
-    ├── HttpError
-    │   └── RateLimitError
-    ├── HttpTimeoutError
-    ├── InvalidJsonError
-    └── ConnectionError
+    ├── WikiHttpError
+    │   └── WikiRateLimitError
+    ├── WikiHttpTimeoutError
+    ├── WikiInvalidJsonError
+    └── WikiConnectionError
 
 Retry Behavior
 --------------

--- a/README.rst
+++ b/README.rst
@@ -330,15 +330,15 @@ exceptions are exposed. You can catch specific exceptions or the base ``Wikipedi
     try:
         page = wiki_wiki.page('Python_(programming_language)')
         print(page.summary[0:60])
-    except wikipediaapi.RateLimitError as e:
+    except wikipediaapi.WikiRateLimitError as e:
         print("Rate limited! Retry after: %s seconds" % e.retry_after)
-    except wikipediaapi.HttpError as e:
+    except wikipediaapi.WikiHttpError as e:
         print("HTTP error %d: %s" % (e.status_code, e))
-    except wikipediaapi.HttpTimeoutError:
+    except wikipediaapi.WikiHttpTimeoutError:
         print("Request timed out")
-    except wikipediaapi.ConnectionError:
+    except wikipediaapi.WikiConnectionError:
         print("Could not connect to Wikipedia")
-    except wikipediaapi.InvalidJsonError:
+    except wikipediaapi.WikiInvalidJsonError:
         print("Received invalid response from Wikipedia")
 
 Retry Configuration

--- a/README.rst
+++ b/README.rst
@@ -305,6 +305,69 @@ specify parameter `converttitles`. If you want to specify it, you can use:
 .. _sandbox: https://en.wikipedia.org/wiki/Special:ApiSandbox
 .. _info API call: https://zh.wikipedia.org/wiki/Special:API%E6%B2%99%E7%9B%92#action=query&format=json&variant=zh-tw&prop=info&titles=%E5%AD%9F%E5%8D%AF&converttitles=1&formatversion=2&inprop=varianttitles%7Cdisplaytitle
 
+Error Handling
+~~~~~~~~~~~~~~
+
+All exceptions raised by the library inherit from ``WikipediaException``. No ``requests`` or ``json``
+exceptions are exposed. You can catch specific exceptions or the base ``WikipediaException``.
+
+.. code-block:: python
+
+    import wikipediaapi
+
+    wiki_wiki = wikipediaapi.Wikipedia(user_agent='MyProjectName (merlin@example.com)', language='en')
+
+    # Catch any Wikipedia-API error
+    try:
+        page = wiki_wiki.page('Python_(programming_language)')
+        print(page.summary[0:60])
+    except wikipediaapi.WikipediaException as e:
+        print("Error: %s" % e)
+
+.. code-block:: python
+
+    # Handle rate limiting specifically
+    try:
+        page = wiki_wiki.page('Python_(programming_language)')
+        print(page.summary[0:60])
+    except wikipediaapi.RateLimitError as e:
+        print("Rate limited! Retry after: %s seconds" % e.retry_after)
+    except wikipediaapi.HttpError as e:
+        print("HTTP error %d: %s" % (e.status_code, e))
+    except wikipediaapi.HttpTimeoutError:
+        print("Request timed out")
+    except wikipediaapi.ConnectionError:
+        print("Could not connect to Wikipedia")
+    except wikipediaapi.InvalidJsonError:
+        print("Received invalid response from Wikipedia")
+
+Retry Configuration
+~~~~~~~~~~~~~~~~~~~
+
+By default, transient errors (HTTP 429, 5xx, timeouts, connection errors) are retried up to 3 times
+with exponential backoff. You can configure this behavior in the constructor.
+
+.. code-block:: python
+
+    import wikipediaapi
+
+    # Custom retry: 5 retries with 2-second base wait
+    wiki_wiki = wikipediaapi.Wikipedia(
+        user_agent='MyProjectName (merlin@example.com)',
+        language='en',
+        max_retries=5,
+        retry_wait=2.0,
+    )
+
+.. code-block:: python
+
+    # Disable retries entirely
+    wiki_wiki = wikipediaapi.Wikipedia(
+        user_agent='MyProjectName (merlin@example.com)',
+        language='en',
+        max_retries=0,
+    )
+
 How To See Underlying API Call
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/query_errors_test.py
+++ b/tests/query_errors_test.py
@@ -1,0 +1,318 @@
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from tests.mock_data import user_agent
+import wikipediaapi
+
+
+class TestQueryHttpErrors(unittest.TestCase):
+    """Tests for _query HTTP error handling."""
+
+    def setUp(self):
+        self.wiki = wikipediaapi.Wikipedia(
+            user_agent, "en", max_retries=0, retry_wait=0.0
+        )
+        self.page = self.wiki.page("Test")
+
+    def _mock_response(self, status_code=200, json_data=None, headers=None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = headers or {}
+        if json_data is not None:
+            resp.json.return_value = json_data
+        else:
+            resp.json.side_effect = ValueError("No JSON")
+        return resp
+
+    @patch("requests.Session.get")
+    def test_http_404_raises_http_error(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=404)
+        with self.assertRaises(wikipediaapi.WikiHttpError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIsInstance(ctx.exception, wikipediaapi.WikipediaException)
+
+    @patch("requests.Session.get")
+    def test_http_403_raises_http_error(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=403)
+        with self.assertRaises(wikipediaapi.WikiHttpError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("requests.Session.get")
+    def test_http_429_raises_rate_limit_error(self, mock_get):
+        mock_get.return_value = self._mock_response(
+            status_code=429, headers={"Retry-After": "5"}
+        )
+        with self.assertRaises(wikipediaapi.WikiRateLimitError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(ctx.exception.status_code, 429)
+        self.assertEqual(ctx.exception.retry_after, 5)
+        self.assertIsInstance(ctx.exception, wikipediaapi.WikiHttpError)
+
+    @patch("requests.Session.get")
+    def test_http_429_without_retry_after(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=429)
+        with self.assertRaises(wikipediaapi.WikiRateLimitError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertIsNone(ctx.exception.retry_after)
+
+    @patch("requests.Session.get")
+    def test_http_500_raises_http_error(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=500)
+        with self.assertRaises(wikipediaapi.WikiHttpError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(ctx.exception.status_code, 500)
+
+    @patch("requests.Session.get")
+    def test_http_503_raises_http_error(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=503)
+        with self.assertRaises(wikipediaapi.WikiHttpError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(ctx.exception.status_code, 503)
+
+    @patch("requests.Session.get")
+    def test_invalid_json_raises_invalid_json_error(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=200)
+        with self.assertRaises(wikipediaapi.WikiInvalidJsonError):
+            self.wiki._query(self.page, {"action": "query"})
+
+    @patch("requests.Session.get")
+    def test_timeout_raises_http_timeout_error(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.exceptions.Timeout()
+        with self.assertRaises(wikipediaapi.WikiHttpTimeoutError):
+            self.wiki._query(self.page, {"action": "query"})
+
+    @patch("requests.Session.get")
+    def test_connection_error_raises_connection_error(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.exceptions.ConnectionError()
+        with self.assertRaises(wikipediaapi.WikiConnectionError):
+            self.wiki._query(self.page, {"action": "query"})
+
+    @patch("requests.Session.get")
+    def test_request_exception_raises_connection_error(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.exceptions.RequestException()
+        with self.assertRaises(wikipediaapi.WikiConnectionError):
+            self.wiki._query(self.page, {"action": "query"})
+
+    @patch("requests.Session.get")
+    def test_http_200_valid_json_returns_data(self, mock_get):
+        expected = {"query": {"pages": {}}}
+        mock_get.return_value = self._mock_response(status_code=200, json_data=expected)
+        result = self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(result, expected)
+
+
+class TestQueryRetryLogic(unittest.TestCase):
+    """Tests for _query retry behavior."""
+
+    def setUp(self):
+        self.wiki = wikipediaapi.Wikipedia(
+            user_agent, "en", max_retries=2, retry_wait=0.0
+        )
+        self.page = self.wiki.page("Test")
+
+    def _mock_response(self, status_code=200, json_data=None, headers=None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = headers or {}
+        if json_data is not None:
+            resp.json.return_value = json_data
+        else:
+            resp.json.side_effect = ValueError("No JSON")
+        return resp
+
+    @patch("requests.Session.get")
+    def test_retry_on_429_then_success(self, mock_get):
+        success_data = {"query": {"pages": {}}}
+        mock_get.side_effect = [
+            self._mock_response(status_code=429),
+            self._mock_response(status_code=200, json_data=success_data),
+        ]
+        result = self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(result, success_data)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("requests.Session.get")
+    def test_retry_on_500_then_success(self, mock_get):
+        success_data = {"query": {"pages": {}}}
+        mock_get.side_effect = [
+            self._mock_response(status_code=500),
+            self._mock_response(status_code=200, json_data=success_data),
+        ]
+        result = self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(result, success_data)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("requests.Session.get")
+    def test_retry_on_timeout_then_success(self, mock_get):
+        import requests
+
+        success_data = {"query": {"pages": {}}}
+        mock_get.side_effect = [
+            requests.exceptions.Timeout(),
+            self._mock_response(status_code=200, json_data=success_data),
+        ]
+        result = self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(result, success_data)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("requests.Session.get")
+    def test_retry_on_connection_error_then_success(self, mock_get):
+        import requests
+
+        success_data = {"query": {"pages": {}}}
+        mock_get.side_effect = [
+            requests.exceptions.ConnectionError(),
+            self._mock_response(status_code=200, json_data=success_data),
+        ]
+        result = self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(result, success_data)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("requests.Session.get")
+    def test_max_retries_exhausted_raises(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=429)
+        with self.assertRaises(wikipediaapi.WikiRateLimitError):
+            self.wiki._query(self.page, {"action": "query"})
+        # 1 initial + 2 retries = 3 attempts
+        self.assertEqual(mock_get.call_count, 3)
+
+    @patch("requests.Session.get")
+    def test_max_retries_exhausted_on_500(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=500)
+        with self.assertRaises(wikipediaapi.WikiHttpError) as ctx:
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(ctx.exception.status_code, 500)
+        self.assertEqual(mock_get.call_count, 3)
+
+    @patch("requests.Session.get")
+    def test_max_retries_exhausted_on_timeout(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.exceptions.Timeout()
+        with self.assertRaises(wikipediaapi.WikiHttpTimeoutError):
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(mock_get.call_count, 3)
+
+    @patch("requests.Session.get")
+    def test_no_retry_on_4xx(self, mock_get):
+        """Non-retryable 4xx errors should raise immediately without retries."""
+        mock_get.return_value = self._mock_response(status_code=404)
+        with self.assertRaises(wikipediaapi.WikiHttpError):
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("requests.Session.get")
+    def test_retry_429_with_retry_after_header(self, mock_get):
+        success_data = {"query": {"pages": {}}}
+        mock_get.side_effect = [
+            self._mock_response(status_code=429, headers={"Retry-After": "1"}),
+            self._mock_response(status_code=200, json_data=success_data),
+        ]
+        result = self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(result, success_data)
+
+    @patch("requests.Session.get")
+    def test_no_retry_on_invalid_json(self, mock_get):
+        """Invalid JSON on 200 should raise immediately, no retry."""
+        mock_get.return_value = self._mock_response(status_code=200)
+        with self.assertRaises(wikipediaapi.WikiInvalidJsonError):
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("requests.Session.get")
+    def test_no_retry_on_request_exception(self, mock_get):
+        """Generic RequestException (not Timeout/ConnectionError) should not retry."""
+        import requests
+
+        mock_get.side_effect = requests.exceptions.RequestException()
+        with self.assertRaises(wikipediaapi.WikiConnectionError):
+            self.wiki._query(self.page, {"action": "query"})
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_max_retries_zero_disables_retry(self):
+        wiki = wikipediaapi.Wikipedia(user_agent, "en", max_retries=0, retry_wait=0.0)
+        self.assertEqual(wiki._max_retries, 0)
+
+
+class TestExceptionHierarchy(unittest.TestCase):
+    """Tests for custom exception class hierarchy."""
+
+    def test_wikipedia_exception_is_base(self):
+        self.assertTrue(
+            issubclass(wikipediaapi.WikiHttpError, wikipediaapi.WikipediaException)
+        )
+        self.assertTrue(
+            issubclass(
+                wikipediaapi.WikiHttpTimeoutError, wikipediaapi.WikipediaException
+            )
+        )
+        self.assertTrue(
+            issubclass(
+                wikipediaapi.WikiInvalidJsonError, wikipediaapi.WikipediaException
+            )
+        )
+        self.assertTrue(
+            issubclass(
+                wikipediaapi.WikiConnectionError, wikipediaapi.WikipediaException
+            )
+        )
+
+    def test_rate_limit_error_is_http_error(self):
+        self.assertTrue(
+            issubclass(wikipediaapi.WikiRateLimitError, wikipediaapi.WikiHttpError)
+        )
+
+    def test_exception_messages(self):
+        e = wikipediaapi.WikiHttpError(404, "http://example.com")
+        self.assertIn("404", str(e))
+        self.assertIn("http://example.com", str(e))
+
+        e = wikipediaapi.WikiRateLimitError("http://example.com", retry_after=5)
+        self.assertEqual(e.retry_after, 5)
+        self.assertEqual(e.status_code, 429)
+
+        e = wikipediaapi.WikiHttpTimeoutError("http://example.com")
+        self.assertIn("http://example.com", str(e))
+
+        e = wikipediaapi.WikiInvalidJsonError("http://example.com")
+        self.assertIn("http://example.com", str(e))
+
+        e = wikipediaapi.WikiConnectionError("http://example.com")
+        self.assertIn("http://example.com", str(e))
+
+    def test_exceptions_do_not_expose_requests(self):
+        """Ensure our exceptions don't inherit from requests exceptions."""
+        import requests
+
+        self.assertFalse(
+            issubclass(
+                wikipediaapi.WikipediaException,
+                requests.exceptions.RequestException,
+            )
+        )
+
+
+class TestDefaultRetryParams(unittest.TestCase):
+    """Tests for default retry parameters in Wikipedia constructor."""
+
+    def test_default_max_retries(self):
+        wiki = wikipediaapi.Wikipedia(user_agent, "en")
+        self.assertEqual(wiki._max_retries, 3)
+
+    def test_default_retry_wait(self):
+        wiki = wikipediaapi.Wikipedia(user_agent, "en")
+        self.assertEqual(wiki._retry_wait, 1.0)
+
+    def test_custom_retry_params(self):
+        wiki = wikipediaapi.Wikipedia(user_agent, "en", max_retries=5, retry_wait=2.0)
+        self.assertEqual(wiki._max_retries, 5)
+        self.assertEqual(wiki._retry_wait, 2.0)

--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from enum import IntEnum
 import logging
 import re
+import time
 from typing import Any, Optional, Union
 from urllib import parse
 
@@ -27,6 +28,53 @@ MIN_USER_AGENT_LEN = 5
 MAX_LANG_LEN = 5
 
 log = logging.getLogger(__name__)
+
+
+class WikipediaException(Exception):
+    """Base exception for Wikipedia-API."""
+
+
+class HttpTimeoutError(WikipediaException):
+    """Request to Wikipedia API timed out."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        super().__init__(url)
+
+
+class HttpError(WikipediaException):
+    """Non-success HTTP status from Wikipedia API."""
+
+    def __init__(self, status_code: int, url: str) -> None:
+        self.status_code = status_code
+        self.url = url
+        super().__init__(status_code, url)
+
+
+class RateLimitError(HttpError):
+    """HTTP 429 - Too Many Requests."""
+
+    def __init__(
+        self, url: str, retry_after: Optional[int] = None
+    ) -> None:  # noqa: B042
+        self.retry_after = retry_after
+        super().__init__(429, url)
+
+
+class InvalidJsonError(WikipediaException):
+    """Response body was not valid JSON."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        super().__init__(url)
+
+
+class ConnectionError(WikipediaException):
+    """Could not connect to Wikipedia API."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        super().__init__(url)
 
 
 # https://www.mediawiki.org/wiki/API:Main_page
@@ -140,6 +188,8 @@ class Wikipedia:
         extract_format: ExtractFormat = ExtractFormat.WIKI,
         headers: Optional[dict[str, Any]] = None,
         extra_api_params: Optional[dict[str, Any]] = None,
+        max_retries: int = 3,
+        retry_wait: float = 1.0,
         **request_kwargs,
     ) -> None:
         """
@@ -156,6 +206,12 @@ class Wikipedia:
         :param headers:  Headers sent as part of HTTP request
         :param extra_api_params:  Extra parameters that are used to construct
                 query string when calling Wikipedia API
+        :param max_retries: Maximum number of retries for transient errors
+                (HTTP 429, 5xx, timeouts, connection errors). Set to 0 to
+                disable retries.
+        :param retry_wait: Base wait time in seconds between retries.
+                Uses exponential backoff: retry_wait * 2^attempt.
+                For HTTP 429, the Retry-After header is used if present.
         :param request_kwargs: Optional parameters used in -
                 http://docs.python-requests.org/en/master/api/#requests.request
 
@@ -191,6 +247,8 @@ class Wikipedia:
         )
 
         self._extra_api_params = extra_api_params
+        self._max_retries = max_retries
+        self._retry_wait = retry_wait
 
         self._session = requests.Session()
         self._session.headers.update(default_headers)
@@ -536,8 +594,82 @@ class Wikipedia:
             + "&".join([k + "=" + str(v) for k, v in used_params.items()]),
         )
 
-        r = self._session.get(base_url, params=used_params, **self._request_kwargs)
-        return r.json()
+        last_exc: Optional[WikipediaException] = None
+        for attempt in range(1 + self._max_retries):
+            try:
+                r = self._session.get(
+                    base_url, params=used_params, **self._request_kwargs
+                )
+            except requests.exceptions.Timeout:
+                last_exc = HttpTimeoutError(base_url)
+                log.warning(
+                    "Timeout (attempt %d/%d): %s",
+                    attempt + 1,
+                    1 + self._max_retries,
+                    base_url,
+                )
+                if attempt < self._max_retries:
+                    time.sleep(self._retry_wait * (2**attempt))
+                continue
+            except requests.exceptions.ConnectionError:
+                last_exc = ConnectionError(base_url)
+                log.warning(
+                    "Connection error (attempt %d/%d): %s",
+                    attempt + 1,
+                    1 + self._max_retries,
+                    base_url,
+                )
+                if attempt < self._max_retries:
+                    time.sleep(self._retry_wait * (2**attempt))
+                continue
+            except requests.exceptions.RequestException:
+                raise ConnectionError(base_url)
+
+            if r.status_code == 429:
+                retry_after = r.headers.get("Retry-After")
+                wait = (
+                    int(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else self._retry_wait * (2**attempt)
+                )
+                last_exc = RateLimitError(
+                    base_url,
+                    int(retry_after) if retry_after and retry_after.isdigit() else None,
+                )
+                log.warning(
+                    "Rate limited (attempt %d/%d), waiting %.1fs: %s",
+                    attempt + 1,
+                    1 + self._max_retries,
+                    wait,
+                    base_url,
+                )
+                if attempt < self._max_retries:
+                    time.sleep(wait)
+                continue
+
+            if r.status_code >= 500:
+                last_exc = HttpError(r.status_code, base_url)
+                log.warning(
+                    "Server error %d (attempt %d/%d): %s",
+                    r.status_code,
+                    attempt + 1,
+                    1 + self._max_retries,
+                    base_url,
+                )
+                if attempt < self._max_retries:
+                    time.sleep(self._retry_wait * (2**attempt))
+                continue
+
+            if r.status_code != 200:
+                raise HttpError(r.status_code, base_url)
+
+            try:
+                return r.json()
+            except ValueError:
+                raise InvalidJsonError(base_url)
+
+        assert last_exc is not None
+        raise last_exc
 
     def _construct_params(
         self, page: "WikipediaPage", params: dict[str, Any]

--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -34,7 +34,7 @@ class WikipediaException(Exception):
     """Base exception for Wikipedia-API."""
 
 
-class HttpTimeoutError(WikipediaException):
+class WikiHttpTimeoutError(WikipediaException):
     """Request to Wikipedia API timed out."""
 
     def __init__(self, url: str) -> None:
@@ -42,7 +42,7 @@ class HttpTimeoutError(WikipediaException):
         super().__init__(url)
 
 
-class HttpError(WikipediaException):
+class WikiHttpError(WikipediaException):
     """Non-success HTTP status from Wikipedia API."""
 
     def __init__(self, status_code: int, url: str) -> None:
@@ -51,7 +51,7 @@ class HttpError(WikipediaException):
         super().__init__(status_code, url)
 
 
-class RateLimitError(HttpError):
+class WikiRateLimitError(WikiHttpError):
     """HTTP 429 - Too Many Requests."""
 
     def __init__(
@@ -61,7 +61,7 @@ class RateLimitError(HttpError):
         super().__init__(429, url)
 
 
-class InvalidJsonError(WikipediaException):
+class WikiInvalidJsonError(WikipediaException):
     """Response body was not valid JSON."""
 
     def __init__(self, url: str) -> None:
@@ -69,7 +69,7 @@ class InvalidJsonError(WikipediaException):
         super().__init__(url)
 
 
-class ConnectionError(WikipediaException):
+class WikiConnectionError(WikipediaException):
     """Could not connect to Wikipedia API."""
 
     def __init__(self, url: str) -> None:
@@ -341,11 +341,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: summary of the page
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -379,11 +379,11 @@ class Wikipedia:
         https://www.mediawiki.org/w/api.php?action=help&modules=query%2Binfo
         https://www.mediawiki.org/wiki/API:Info
 
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
         """
         params = {
             "action": "query",
@@ -429,11 +429,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: links to pages in other languages
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -469,11 +469,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: links to linked pages
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -514,11 +514,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: backlinks from other pages
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -553,11 +553,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: categories for page
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
         """
         params = {
             "action": "query",
@@ -591,11 +591,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: pages in given category
-        :raises HttpTimeoutError: if the request times out
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
         """
         params = {
             "action": "query",
@@ -618,6 +618,80 @@ class Wikipedia:
 
         return self._build_categorymembers(v, page)
 
+    def _attempt_request(
+        self, base_url: str, used_params: dict[str, Any]
+    ) -> tuple[Optional[Any], Optional[WikipediaException], bool]:
+        """Perform a single HTTP GET and convert request-layer exceptions.
+
+        :return: ``(response, exc, retryable)`` where *response* is the
+            ``requests.Response`` on success, *exc* is a
+            :class:`WikipediaException` when a request-layer error occurred,
+            and *retryable* indicates whether the caller may retry.
+        """
+        try:
+            return (
+                self._session.get(base_url, params=used_params, **self._request_kwargs),
+                None,
+                False,
+            )
+        except requests.exceptions.Timeout:
+            return None, WikiHttpTimeoutError(base_url), True
+        except requests.exceptions.ConnectionError:
+            return None, WikiConnectionError(base_url), True
+        except requests.exceptions.RequestException:
+            raise WikiConnectionError(base_url)
+
+    def _handle_response(
+        self, r: Any, base_url: str, attempt: int
+    ) -> tuple[Optional[WikipediaException], bool, float]:
+        """Inspect an HTTP response and decide what to do next.
+
+        :return: ``(exc, retryable, wait)`` where *exc* is set for retryable
+            errors, *retryable* is ``True`` when the caller should retry, and
+            *wait* is the number of seconds to sleep before the next attempt.
+            Raises immediately for non-retryable errors.
+        :raises WikiHttpError: for non-retryable 4xx responses
+        :raises WikiInvalidJsonError: when the 200 response body is not JSON
+        """
+        if r.status_code == 429:
+            retry_after = r.headers.get("Retry-After")
+            wait: float = (
+                int(retry_after)
+                if retry_after and retry_after.isdigit()
+                else self._retry_wait * (2**attempt)
+            )
+            exc = WikiRateLimitError(
+                base_url,
+                int(retry_after) if retry_after and retry_after.isdigit() else None,
+            )
+            log.warning(
+                "Rate limited (attempt %d/%d), waiting %.1fs: %s",
+                attempt + 1,
+                1 + self._max_retries,
+                wait,
+                base_url,
+            )
+            return exc, True, wait
+
+        if r.status_code >= 500:
+            log.warning(
+                "Server error %d (attempt %d/%d): %s",
+                r.status_code,
+                attempt + 1,
+                1 + self._max_retries,
+                base_url,
+            )
+            return (
+                WikiHttpError(r.status_code, base_url),
+                True,
+                self._retry_wait * (2**attempt),
+            )
+
+        if r.status_code != 200:
+            raise WikiHttpError(r.status_code, base_url)
+
+        return None, False, 0.0
+
     def _query(self, page: "WikipediaPage", params: dict[str, Any]):
         """Queries Wikimedia API to fetch content.
 
@@ -627,11 +701,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param params: parameters used in API call
         :return: parsed JSON response as dict
-        :raises HttpTimeoutError: if the request times out after all retries
-        :raises ConnectionError: if a connection cannot be established
-        :raises RateLimitError: if the API returns HTTP 429 after all retries
-        :raises HttpError: if the API returns a non-success HTTP status
-        :raises InvalidJsonError: if the response is not valid JSON
+        :raises WikiHttpTimeoutError: if the request times out after all retries
+        :raises WikiConnectionError: if a connection cannot be established
+        :raises WikiRateLimitError: if the API returns HTTP 429 after all retries
+        :raises WikiHttpError: if the API returns a non-success HTTP status
+        :raises WikiInvalidJsonError: if the response is not valid JSON
         """
         base_url = "https://" + page.language + ".wikipedia.org/w/api.php"
         used_params = self._construct_params(page, params)
@@ -645,77 +719,32 @@ class Wikipedia:
 
         last_exc: Optional[WikipediaException] = None
         for attempt in range(1 + self._max_retries):
-            try:
-                r = self._session.get(
-                    base_url, params=used_params, **self._request_kwargs
-                )
-            except requests.exceptions.Timeout:
-                last_exc = HttpTimeoutError(base_url)
+            r, exc, retryable = self._attempt_request(base_url, used_params)
+            if exc is not None:
+                last_exc = exc
                 log.warning(
-                    "Timeout (attempt %d/%d): %s",
+                    "%s (attempt %d/%d): %s",
+                    exc.__class__.__name__,
                     attempt + 1,
                     1 + self._max_retries,
                     base_url,
                 )
-                if attempt < self._max_retries:
+                if retryable and attempt < self._max_retries:
                     time.sleep(self._retry_wait * (2**attempt))
                 continue
-            except requests.exceptions.ConnectionError:
-                last_exc = ConnectionError(base_url)
-                log.warning(
-                    "Connection error (attempt %d/%d): %s",
-                    attempt + 1,
-                    1 + self._max_retries,
-                    base_url,
-                )
-                if attempt < self._max_retries:
-                    time.sleep(self._retry_wait * (2**attempt))
-                continue
-            except requests.exceptions.RequestException:
-                raise ConnectionError(base_url)
 
-            if r.status_code == 429:
-                retry_after = r.headers.get("Retry-After")
-                wait = (
-                    int(retry_after)
-                    if retry_after and retry_after.isdigit()
-                    else self._retry_wait * (2**attempt)
-                )
-                last_exc = RateLimitError(
-                    base_url,
-                    int(retry_after) if retry_after and retry_after.isdigit() else None,
-                )
-                log.warning(
-                    "Rate limited (attempt %d/%d), waiting %.1fs: %s",
-                    attempt + 1,
-                    1 + self._max_retries,
-                    wait,
-                    base_url,
-                )
+            exc, retryable, wait = self._handle_response(r, base_url, attempt)
+            if retryable:
+                last_exc = exc
                 if attempt < self._max_retries:
                     time.sleep(wait)
                 continue
 
-            if r.status_code >= 500:
-                last_exc = HttpError(r.status_code, base_url)
-                log.warning(
-                    "Server error %d (attempt %d/%d): %s",
-                    r.status_code,
-                    attempt + 1,
-                    1 + self._max_retries,
-                    base_url,
-                )
-                if attempt < self._max_retries:
-                    time.sleep(self._retry_wait * (2**attempt))
-                continue
-
-            if r.status_code != 200:
-                raise HttpError(r.status_code, base_url)
-
+            assert r is not None
             try:
                 return r.json()
             except ValueError:
-                raise InvalidJsonError(base_url)
+                raise WikiInvalidJsonError(base_url)
 
         assert last_exc is not None
         raise last_exc

--- a/wikipediaapi/__init__.py
+++ b/wikipediaapi/__init__.py
@@ -341,6 +341,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: summary of the page
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -373,6 +378,12 @@ class Wikipedia:
         """
         https://www.mediawiki.org/w/api.php?action=help&modules=query%2Binfo
         https://www.mediawiki.org/wiki/API:Info
+
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
         """
         params = {
             "action": "query",
@@ -418,6 +429,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: links to pages in other languages
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -453,6 +469,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: links to linked pages
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -493,6 +514,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: backlinks from other pages
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
 
         """
         params = {
@@ -527,6 +553,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: categories for page
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
         """
         params = {
             "action": "query",
@@ -560,6 +591,11 @@ class Wikipedia:
         :param page: :class:`WikipediaPage`
         :param kwargs: parameters used in API call
         :return: pages in given category
+        :raises HttpTimeoutError: if the request times out
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
         """
         params = {
             "action": "query",
@@ -583,7 +619,20 @@ class Wikipedia:
         return self._build_categorymembers(v, page)
 
     def _query(self, page: "WikipediaPage", params: dict[str, Any]):
-        """Queries Wikimedia API to fetch content."""
+        """Queries Wikimedia API to fetch content.
+
+        Transient errors (HTTP 429, 5xx, timeouts, connection errors) are
+        retried up to ``max_retries`` times with exponential backoff.
+
+        :param page: :class:`WikipediaPage`
+        :param params: parameters used in API call
+        :return: parsed JSON response as dict
+        :raises HttpTimeoutError: if the request times out after all retries
+        :raises ConnectionError: if a connection cannot be established
+        :raises RateLimitError: if the API returns HTTP 429 after all retries
+        :raises HttpError: if the API returns a non-success HTTP status
+        :raises InvalidJsonError: if the response is not valid JSON
+        """
         base_url = "https://" + page.language + ".wikipedia.org/w/api.php"
         used_params = self._construct_params(page, params)
 


### PR DESCRIPTION
## Improve error handling, retry logic, and exception naming

Builds on the existing JSON error handling to add full retry support, consistent exception naming, and reduced complexity in [_query](cci:1://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:21:4-24:73).

### Exception renaming

All exceptions prefixed with `Wiki` to avoid shadowing Python built-ins (`PYL-W0622`): [WikiHttpError](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:44:0-50:42), [WikiRateLimitError](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:53:0-60:34), [WikiHttpTimeoutError](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:36:0-41:29), [WikiInvalidJsonError](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:63:0-68:29), [WikiConnectionError](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:71:0-76:29).

### Retry logic

[_query](cci:1://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:21:4-24:73) previously made a single unguarded request. It now retries transient errors (429, 5xx, timeouts, connection errors) with exponential backoff, honours `Retry-After`, and raises immediately for non-retryable errors. Controlled by new [Wikipedia(max_retries=3, retry_wait=1.0)](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:179:0-974:9) constructor parameters.

### [_query](cci:1://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:21:4-24:73) refactor

Cyclomatic complexity reduced from 18 to low by extracting two helpers: [_attempt_request](cci:1://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:620:4-641:47) (one HTTP GET, converts `requests` exceptions) and [_handle_response](cci:1://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:22:4-24:58) (status code dispatch). [_query](cci:1://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:21:4-24:73) is now a thin retry loop.

### Also

- [API.rst](cci:7://file:///Users/martin.majlis/development/Wikipedia-API/API.rst:0:0-0:0) / [README.rst](cci:7://file:///Users/martin.majlis/development/Wikipedia-API/README.rst:0:0-0:0) updated with new exception names and retry docs
- Docstrings on all public [Wikipedia](cci:2://file:///Users/martin.majlis/development/Wikipedia-API/wikipediaapi/__init__.py:179:0-974:9) methods updated with `:raises:` entries
- [tests/query_errors_test.py](cci:7://file:///Users/martin.majlis/development/Wikipedia-API/tests/query_errors_test.py:0:0-0:0) added covering all error paths, retry behaviour, and exception hierarchy