### PR TITLE
Make user agent compliant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,10 @@ Getting single page is straightforward. You have to initialize ``Wikipedia`` (or
 object and ask for page by its name.
 To initialize it, you have to provide:
 
-* `user_agent` to identify your project. Please follow the recommended `format`_.
+* `user_agent` to identify your project. **Must include contact information** (email or website) and follow the Wikimedia Foundation `User-Agent policy`_.
 * `language` to specify language mutation. It has to be one of `supported languages`_.
 
-.. _format: https://meta.wikimedia.org/wiki/User-Agent_policy
+.. _User-Agent policy: https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
 .. _supported languages: http://meta.wikimedia.org/wiki/List_of_Wikipedias
 
 **Synchronous**

--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -28,7 +28,7 @@ from wikipediaapi import coordinates_prop2str
 # Set to INFO to see the actual API request URLs being made
 logging.basicConfig(level=logging.WARNING)
 
-user_agent = "Wikipedia-API Example (merlin@example.com)"
+user_agent = "MyCoolBot/1.0 (myemail@example.com)"
 
 
 def print_sections(sections, level=0):

--- a/examples/example_cli.sh
+++ b/examples/example_cli.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-USER_AGENT="Wikipedia-API Example (merlin@example.com)"
+USER_AGENT="MyCoolBot/1.0 (myemail@example.com)"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # 1. Verify installation

--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -19,7 +19,7 @@ from wikipediaapi import coordinates_prop2str
 # Set to INFO to see the actual API request URLs being made
 logging.basicConfig(level=logging.WARNING)
 
-user_agent = "Wikipedia-API Example (merlin@example.com)"
+user_agent = "MyCoolBot/1.0 (myemail@example.com)"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # 1. Creating a Wikipedia client

--- a/tests/wikipedia_test.py
+++ b/tests/wikipedia_test.py
@@ -13,7 +13,8 @@ class TestWikipedia:
         assert str(e.value) == str(
             AssertionError(
                 "Please, be nice to Wikipedia and specify user agent - "
-                + "https://meta.wikimedia.org/wiki/User-Agent_policy. "
+                + "https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_"
+                + "User-Agent_Policy. "
                 + "Current user_agent: 'en' is not sufficient. "
                 + "Use Wikipedia(user_agent='your-user-agent', language='en')"
             )
@@ -25,7 +26,8 @@ class TestWikipedia:
         assert str(e.value) == str(
             AssertionError(
                 "Please, be nice to Wikipedia and specify user agent - "
-                + "https://meta.wikimedia.org/wiki/User-Agent_policy. "
+                + "https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_"
+                + "User-Agent_Policy. "
                 + "Current user_agent: 'en' is not sufficient. "
                 + "Use Wikipedia(user_agent='your-user-agent', language='en')"
             )
@@ -37,7 +39,8 @@ class TestWikipedia:
         assert str(e.value) == str(
             AssertionError(
                 "Please, be nice to Wikipedia and specify user agent - "
-                + "https://meta.wikimedia.org/wiki/User-Agent_policy. "
+                + "https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_"
+                + "User-Agent_Policy. "
                 + "Current user_agent: '' is not sufficient. "
                 + "Use Wikipedia(user_agent='your-user-agent', language='your-language')"
             )
@@ -65,7 +68,7 @@ class TestWikipedia:
         )
         assert wiki is not None
         user_agent = wiki._client.headers.get("User-Agent")
-        assert user_agent == "param-user-agent (" + wikipediaapi.USER_AGENT + ")"
+        assert user_agent == "param-user-agent " + wikipediaapi.USER_AGENT
         assert wiki.language == "en"
 
     def test_user_agent_in_headers_is_fine(self):
@@ -75,7 +78,7 @@ class TestWikipedia:
         )
         assert wiki is not None
         user_agent = wiki._client.headers.get("User-Agent")
-        assert user_agent == "header-user-agent (" + wikipediaapi.USER_AGENT + ")"
+        assert user_agent == "header-user-agent " + wikipediaapi.USER_AGENT
 
     def test_user_agent_in_headers_win(self):
         wiki = wikipediaapi.Wikipedia(
@@ -84,7 +87,7 @@ class TestWikipedia:
         )
         assert wiki is not None
         user_agent = wiki._client.headers.get("User-Agent")
-        assert user_agent == "header-user-agent (" + wikipediaapi.USER_AGENT + ")"
+        assert user_agent == "header-user-agent " + wikipediaapi.USER_AGENT
 
     def test_extracts_nonexistent_page(self):
         """Test extracts method when page doesn't exist (pageid is negative)."""

--- a/wikipediaapi/_http_client/base_http_client.py
+++ b/wikipediaapi/_http_client/base_http_client.py
@@ -116,7 +116,7 @@ class BaseHTTPClient(ABC):
             default_headers.get("User-Agent"),
         )
 
-        default_headers["User-Agent"] = used_user_agent + " (" + USER_AGENT + ")"
+        default_headers["User-Agent"] = used_user_agent + " " + USER_AGENT
 
         self.language = used_language
         self.variant = used_variant
@@ -224,7 +224,8 @@ class BaseHTTPClient(ABC):
         if not user_agent or len(user_agent) < MIN_USER_AGENT_LEN:
             raise AssertionError(
                 "Please, be nice to Wikipedia and specify user agent - "
-                + "https://meta.wikimedia.org/wiki/User-Agent_policy. Current user_agent: '"
+                + "https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_"
+                + "User-Agent_Policy. Current user_agent: '"
                 + str(user_agent)
                 + "' is not sufficient. "
                 + "Use Wikipedia(user_agent='your-user-agent', language='"


### PR DESCRIPTION
## Summary

- Drop parentheses around the appended `wikipedia-api` token in the `User-Agent` header — the [Wikimedia Foundation User-Agent Policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy) uses space-separated tokens, not `(token)` style.
- Update the policy URL in the error message from the old `meta.wikimedia.org` page to the canonical Foundation policy page.
- Update examples and tests to match.

## Context

This change was originally committed directly to `master` (deb4dd6) on 2026-04-29 and then reverted. This PR reintroduces it through the normal review process.

## Test plan

- [x] `make run-pre-commit` — all hooks pass
- [x] `make run-tests` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #569