### PR TITLE
fix(ci): skip verify job and run record directly when mode is record

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   cli-verify:
     name: CLI integration tests (verify)
+    if: "!(github.event_name == 'workflow_dispatch' && inputs.mode == 'record')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,8 +81,11 @@ jobs:
     name: CLI integration tests (record)
     needs: cli-verify
     if: >
-      (github.event_name == 'workflow_dispatch' && inputs.mode == 'record') ||
-      (needs.cli-verify.outputs.small_mismatches > 1 && github.event_name != 'pull_request')
+      always() &&
+      (
+        (github.event_name == 'workflow_dispatch' && inputs.mode == 'record') ||
+        (needs.cli-verify.result == 'success' && needs.cli-verify.outputs.small_mismatches > 1 && github.event_name != 'pull_request')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- `cli-verify` was always running before `cli-record`, even when triggered manually with `mode=record`
- With stale fixtures, verify exits 1 → GitHub Actions skips `cli-record` due to `needs` dependency → fixtures can never be refreshed
- Fix: add `if` condition to skip `cli-verify` entirely in record mode; add `always()` to `cli-record` so it runs when verify was skipped

## Behaviour after this fix

| Trigger | cli-verify | cli-record runs if… |
|---------|-----------|----------------------|
| `workflow_dispatch` `mode=record` | skipped | always |
| `workflow_dispatch` `mode=verify` | runs | verify succeeded + small mismatches > 1 |
| scheduled / push | runs | verify succeeded + small mismatches > 1 |
| pull request | runs | never |

## Test plan

- [x] Manually trigger with `mode=record` — verify job should be skipped, record job should run
- [x] Manually trigger with `mode=verify` — verify runs, record only if small mismatches exist
- [x] Scheduled run — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)