### PR TITLE
fix(ci): align all codeql-action steps to v4.37.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      # Keep the codeql-action sub-actions (init/autobuild/analyze) on the
+      # same version so they never drift apart and break the Analyze job.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
## Problem

The **CodeQL Analyze (python)** job fails at the Autobuild step:

```
We were unable to automatically build your code. Please replace the call to the
autobuild action with your custom build steps. Loaded a configuration file for
version '4.36.3', but running version '4.37.4'
```

## Cause

Dependabot treats each `github/codeql-action/*` sub-action as a **separate dependency**, so it bumped them in independent PRs and they drifted to three different versions:

| Step | Was |
|---|---|
| `init` | v4.36.3 |
| `autobuild` | v4.37.4 |
| `analyze` | v4.37.9 |

`init` records the CodeQL version into the run's config; the later steps must load that config with a matching version. Since `init` lagged, Autobuild refused to load the older config.

## Fix (two parts)

1. **Align the versions now** — pin all three steps to the same commit, `v4.37.9` (`cdf488f`), which `analyze` already used. The sub-actions share one repo, so the tag resolves to one SHA for all three.

2. **Prevent the drift recurring** — add a Dependabot `group` matching `github/codeql-action*` so all three sub-actions are bumped **together in a single PR** and always stay on the same version.

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action*"
```

Independent of #656 (merged) which handled the twine / dependabot-label / dependency-pinning issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)