### PR TITLE
Support passing a custom transport to the httpx client (#615)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Allow passing a custom ``transport`` to the underlying ``httpx`` client (e.g. a caching transport such as Hishel) - `Issue 615`_
+
+.. _Issue 615: https://github.com/martin-majlis/Wikipedia-API/issues/615
+
 0.15.0
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@ Changelog
 Unreleased
 ----------
 
-* Allow passing a custom ``transport`` to the underlying ``httpx`` client (e.g. a caching transport such as Hishel) - `Issue 615`_
+* Allow passing a custom ``transport`` to the underlying ``httpx`` client (e.g. a caching transport such as Hishel) - `PR 659`_
 
-.. _Issue 615: https://github.com/martin-majlis/Wikipedia-API/issues/615
+.. _PR 659: https://github.com/martin-majlis/Wikipedia-API/pull/659
 
 0.15.0
 ----------

--- a/DESIGN.rst
+++ b/DESIGN.rst
@@ -317,6 +317,8 @@ SyncHTTPClient
 Provides a blocking ``_get(language, params) -> dict`` method in ``sync_http_client.py`` backed by
 ``httpx.Client``.  Retry logic uses ``tenacity`` with exponential
 backoff; ``Retry-After`` headers are honoured for HTTP 429 responses.
+The client defaults to ``httpx.HTTPTransport`` but honours a caller-supplied
+``transport`` kwarg (e.g. a caching transport).
 
 AsyncHTTPClient
 ~~~~~~~~~~~~~~~
@@ -324,6 +326,8 @@ AsyncHTTPClient
 Provides an ``async def _get(language, params) -> dict`` coroutine in ``async_http_client.py``
 backed by ``httpx.AsyncClient``.  Retry logic mirrors
 ``SyncHTTPClient`` but uses ``tenacity``'s ``AsyncRetrying``.
+The client defaults to ``httpx.AsyncHTTPTransport`` but honours a caller-supplied
+``transport`` kwarg.
 
 Both clients construct the endpoint URL as::
 

--- a/README.rst
+++ b/README.rst
@@ -1012,6 +1012,31 @@ The same options apply to both ``Wikipedia`` and ``AsyncWikipedia``.
         max_retries=0,
     )
 
+Custom HTTP Transport
+~~~~~~~~~~~~~~~~~~~~~~
+
+Any keyword argument that is not recognised by ``Wikipedia`` / ``AsyncWikipedia`` is
+forwarded to the underlying ``httpx`` client. This includes ``transport``, which lets you
+plug in a custom transport such as a caching transport
+(e.g. `Hishel <https://hishel.com/httpx.html>`_). When ``transport`` is omitted, the default
+``httpx.HTTPTransport`` (sync) / ``httpx.AsyncHTTPTransport`` (async) is used.
+
+.. code-block:: python
+
+    import hishel
+    import httpx
+    import wikipediaapi
+
+    # Cache responses so repeated lookups avoid hitting Wikipedia again
+    wiki_wiki = wikipediaapi.Wikipedia(
+        user_agent='MyProjectName (merlin@example.com)',
+        language='en',
+        transport=hishel.CacheTransport(transport=httpx.HTTPTransport()),
+    )
+
+For ``AsyncWikipedia`` use an async transport (e.g.
+``hishel.AsyncCacheTransport(transport=httpx.AsyncHTTPTransport())``).
+
 How To See Underlying API Call
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/http_client_kwargs_test.py
+++ b/tests/http_client_kwargs_test.py
@@ -153,6 +153,19 @@ class TestSyncHTTPClientKwargs:
         with pytest.raises(TypeError):
             create_mock_wikipedia(invalid_param="should_fail")
 
+    @respx.mock
+    def test_custom_transport_is_used(self):
+        """Test that a caller-supplied transport is forwarded to .Client."""
+        transport = httpx.HTTPTransport()
+        wiki = create_mock_wikipedia(transport=transport)
+        assert wiki._client._transport is transport
+
+    @respx.mock
+    def test_default_transport_when_not_supplied(self):
+        """Test that the default transport is used when none is supplied."""
+        wiki = create_mock_wikipedia()
+        assert isinstance(wiki._client._transport, httpx.HTTPTransport)
+
 
 class TestAsyncHTTPClientKwargs:
     """Test kwargs forwarding in AsyncHTTPClient."""
@@ -271,6 +284,19 @@ class TestAsyncHTTPClientKwargs:
         # httpx should raise an error for invalid parameters
         with pytest.raises(TypeError):
             create_mock_async_wikipedia(invalid_param="should_fail")
+
+    @respx.mock
+    async def test_custom_transport_is_used(self):
+        """Test that a caller-supplied transport is forwarded to .AsyncClient."""
+        transport = httpx.AsyncHTTPTransport()
+        wiki = create_mock_async_wikipedia(transport=transport)
+        assert wiki._client._transport is transport
+
+    @respx.mock
+    async def test_default_transport_when_not_supplied(self):
+        """Test that the default transport is used when none is supplied."""
+        wiki = create_mock_async_wikipedia()
+        assert isinstance(wiki._client._transport, httpx.AsyncHTTPTransport)
 
 
 class TestKwargsBackwardCompatibility:

--- a/wikipediaapi/_http_client/async_http_client.py
+++ b/wikipediaapi/_http_client/async_http_client.py
@@ -48,10 +48,12 @@ class AsyncHTTPClient(BaseHTTPClient):
             :class:`BaseHTTPClient`
         """
         super().__init__(*args, **kwargs)
+        # Use a caller-supplied transport (e.g. a caching transport such as
+        # Hishel) if one was passed; otherwise fall back to the default.
+        self._client_kwargs.setdefault("transport", httpx.AsyncHTTPTransport())
         self._client = httpx.AsyncClient(
             headers=self._default_headers,
             **self._client_kwargs,
-            transport=httpx.AsyncHTTPTransport(),
         )
 
     async def _do_get(self, url: str, params: dict[str, Any]) -> dict[str, Any]:

--- a/wikipediaapi/_http_client/base_http_client.py
+++ b/wikipediaapi/_http_client/base_http_client.py
@@ -96,6 +96,10 @@ class BaseHTTPClient(ABC):
         :param kwargs: forwarded to ``httpx`` client constructor
             (e.g. ``timeout=30.0``, ``proxy={'https://': 'http://proxy.example.com:8080'}``,
             ``verify=False``, ``http2=True``); ``timeout`` defaults to ``10.0``.
+            A custom ``transport`` may also be supplied (e.g. a caching
+            transport such as `Hishel <https://hishel.com/httpx.html>`_); when
+            omitted, the default ``httpx.HTTPTransport`` /
+            ``httpx.AsyncHTTPTransport`` is used.
             **Advanced Usage**: These parameters provide direct access to httpx
             capabilities.  For standard Wikipedia API usage, prefer the
             documented parameters above.  Use httpx parameters only for

--- a/wikipediaapi/_http_client/sync_http_client.py
+++ b/wikipediaapi/_http_client/sync_http_client.py
@@ -46,10 +46,12 @@ class SyncHTTPClient(BaseHTTPClient):
             :class:`BaseHTTPClient`
         """
         super().__init__(*args, **kwargs)
+        # Use a caller-supplied transport (e.g. a caching transport such as
+        # Hishel) if one was passed; otherwise fall back to the default.
+        self._client_kwargs.setdefault("transport", httpx.HTTPTransport())
         self._client = httpx.Client(
             headers=self._default_headers,
             **self._client_kwargs,
-            transport=httpx.HTTPTransport(),
         )
 
     def _do_get(self, url: str, params: dict[str, Any]) -> dict[str, Any]:

--- a/wikipediaapi/_wikipedia/async_wikipedia.py
+++ b/wikipediaapi/_wikipedia/async_wikipedia.py
@@ -66,7 +66,8 @@ class AsyncWikipedia(AsyncWikipediaResource, AsyncHTTPClient):
         ``1.0``.
     :param kwargs: additional keyword arguments forwarded to
         ``httpx.AsyncClient`` (e.g. ``timeout=30.0``, ``proxies={…}``,
-        ``verify=False``).  **Advanced Usage**: These provide direct
+        ``verify=False``, or a custom ``transport`` such as a caching
+        transport).  **Advanced Usage**: These provide direct
         access to httpx capabilities.  For most use cases, prefer the
         standard parameters above.  Use httpx parameters only for specific
         requirements like custom proxies, SSL configuration, or connection pooling.

--- a/wikipediaapi/_wikipedia/wikipedia.py
+++ b/wikipediaapi/_wikipedia/wikipedia.py
@@ -58,7 +58,8 @@ class Wikipedia(WikipediaResource, SyncHTTPClient):
         ``1.0``.
     :param kwargs: additional keyword arguments forwarded to
         ``httpx.Client`` (e.g. ``timeout=30.0``, ``proxies={…}``,
-        ``verify=False``).  **Advanced Usage**: These provide direct
+        ``verify=False``, or a custom ``transport`` such as a caching
+        transport).  **Advanced Usage**: These provide direct
         access to httpx capabilities.  For most use cases, prefer the
         standard parameters above.  Use httpx parameters only for specific
         requirements like custom proxies, SSL configuration, or connection pooling.


### PR DESCRIPTION
## Summary

Closes #615.

Callers can now pass a custom httpx `transport` to `Wikipedia` / `AsyncWikipedia`, enabling caching transports such as [Hishel](https://hishel.com/httpx.html).

Previously both clients hardcoded `transport=httpx.HTTPTransport()` **after** `**self._client_kwargs`, so passing `transport=...` raised `TypeError: got multiple values for keyword argument 'transport'`. The default transport is now injected via `setdefault` (mirroring the existing `timeout` default), so a caller-supplied transport is honoured and the correct default (`httpx.HTTPTransport` / `httpx.AsyncHTTPTransport`) applies when none is given.

```python
import hishel, httpx, wikipediaapi

wiki = wikipediaapi.Wikipedia(
    user_agent="MyProject/1.0 (contact@example.com)",
    language="en",
    transport=hishel.CacheTransport(transport=httpx.HTTPTransport()),
)
```

## Changes

- `sync_http_client.py` / `async_http_client.py`: inject default transport only when the caller didn't supply one.
- Docstrings (`base_http_client.py`, `wikipedia.py`, `async_wikipedia.py`) mention the `transport` kwarg.
- `README.rst` (and `index.rst`, a symlink): new "Custom HTTP Transport" section; `DESIGN.rst` notes.
- `CHANGES.rst`: `Unreleased` entry.
- Tests: custom-transport-used and default-transport-when-absent, sync + async.

## Verification

- Full suite: **899 passed, 3 skipped, 94% coverage**.
- `make run-ruff`, `make run-type-check`, `make run-pre-commit`: all pass.
- End-to-end sanity via `httpx.MockTransport`: sync and async page summaries served through the custom transport with no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)